### PR TITLE
Bugfix for `iter_nuis` infinite loop with multiple `fldir` values

### DIFF
--- a/preproc_script_2.sh
+++ b/preproc_script_2.sh
@@ -85,9 +85,9 @@ iter_nuis() {
     declare -p nuis_arr >/dev/null
   fi
 
-  for i in "${nuis_arr[@]}"
+  for nuis_iter in "${nuis_arr[@]}"
     do
-      paste_files="${paste_files} $(eval_nuis "$i")"
+      paste_files="${paste_files} $(eval_nuis "$nuis_iter")"
     done
 
   if [ "$paste_files" != "" ]; then
@@ -137,9 +137,9 @@ eval_nuis() {
 
 eval_model_wmcsf() {
 #  nuis_arr="$1"
-  for i in "${nuis_arr[@]}"
+  for wmcsf_iter in "${nuis_arr[@]}"
     do
-      if [[ $model == mouse ]] && [[ $i == wmcsf ]]; then
+      if [[ $model == mouse ]] && [[ $wmcsf_iter == wmcsf ]]; then
         printf "ERROR: Model cannot be mouse with wmcsf selected. Exiting...\n"
         exit 1
       fi


### PR DESCRIPTION
Bugfix for `iter_nuis` infinite loop with multiple `fldir` values.

**Problem:**
- Currently `preproc_script_2.sh` will run infinitely if multiple `fldir` directories are specified. 

**Proposed Solution:**
- Fix all loop iterators in the nuisance regressor functions so they are not reset each time `nuis_args` is parsed.

**Committed Changes:**
- Changed iterator name for nuis_iter and wmcsf functions